### PR TITLE
leaderboardName not used in changeScoreForMemberIn

### DIFF
--- a/src/main/java/com/agoragames/leaderboard/Leaderboard.java
+++ b/src/main/java/com/agoragames/leaderboard/Leaderboard.java
@@ -234,7 +234,7 @@ public class Leaderboard {
 	 */
 	public double changeScoreFor(String member, double delta) {
 		return changeScoreForMemberIn(_leaderboardName, member, delta);
-	}
+}	
 	
 	/**
 	 * Change the score for a member by a certain delta in the named leaderboard
@@ -245,7 +245,7 @@ public class Leaderboard {
 	 * @return Updated score
 	 */
 	public double changeScoreForMemberIn(String leaderboardName, String member, double delta) {
-		return _jedis.zincrby(_leaderboardName, delta, member); 
+		return _jedis.zincrby(leaderboardName, delta, member); 
 	}
 	
 	/**

--- a/src/test/java/com/agoragames/leaderboard/LeaderboardTest.java
+++ b/src/test/java/com/agoragames/leaderboard/LeaderboardTest.java
@@ -88,6 +88,19 @@ public class LeaderboardTest extends TestCase {
 		_leaderboard.changeScoreFor("member", -5);
 		assertEquals((double) 5, _leaderboard.scoreFor("member"));
 	}
+	
+	public void testchangeScoreForMemberIn() {
+		String leaderboardName = "localLeaderboardName";
+		
+		_leaderboard.rankMemberIn(leaderboardName, "member", 5);
+		assertEquals((double) 5,  _leaderboard.scoreForIn(leaderboardName, "member"));
+
+		_leaderboard.changeScoreForMemberIn(leaderboardName, "member", 5);
+		assertEquals((double) 10, _leaderboard.scoreForIn(leaderboardName, "member"));
+
+		_leaderboard.changeScoreForMemberIn(leaderboardName, "member", -5);
+		assertEquals((double) 5, _leaderboard.scoreForIn(leaderboardName, "member"));
+	}
 
 	public void testCheckMember() {
 		rankMembersInLeaderboard(5);


### PR DESCRIPTION
The parameter leaderboardName is not used in the method changeScoreForMemberIn. Instead, the _leaderboardName field is used. This leads to changing a score in a different leaderboard, rather than the intended one. If needed, I can add some tests to verify this.